### PR TITLE
Version Selector

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::github::{Release, Tag};
+use crate::github::{Release, ReleaseAndTag, Tag};
 
 // Application state shared between UI thread and update thread
 #[derive(Clone)]
@@ -16,6 +16,10 @@ pub struct AppState {
     current_version: Option<String>,
     nextui_release: Option<Release>,
     nextui_tag: Option<Tag>,
+    nextui_releases_and_tags: Option<Vec<ReleaseAndTag>>,
+    nextui_releases_and_tags_index: Option<usize>,
+    release_selection_menu: bool,
+    release_selection_confirmed: bool,
     current_operation: Option<String>,
     progress: Option<Progress>,
     error: Option<String>,
@@ -40,6 +44,10 @@ impl AppStateManager {
                 current_version: None,
                 nextui_release: None,
                 nextui_tag: None,
+                nextui_releases_and_tags: None,
+                nextui_releases_and_tags_index: None,
+                release_selection_menu: false,
+                release_selection_confirmed: false,
                 current_operation: None,
                 progress: None,
                 error: None,
@@ -93,6 +101,22 @@ impl AppStateManager {
         self.state.lock().nextui_tag.clone()
     }
 
+    pub fn nextui_releases_and_tags(&self) -> Option<Vec<ReleaseAndTag>> {
+        self.state.lock().nextui_releases_and_tags.clone()
+    }
+
+    pub fn nextui_releases_and_tags_index(&self) -> Option<usize> {
+        self.state.lock().nextui_releases_and_tags_index.clone()
+    }
+
+    pub fn release_selection_menu(&self) -> bool {
+        self.state.lock().release_selection_menu
+    }
+
+    pub fn release_selection_confirmed(&self) -> bool {
+        self.state.lock().release_selection_confirmed
+    }
+
     // Setter methods
     pub fn set_submenu(&self, submenu: Submenu) {
         self.state.lock().submenu = submenu;
@@ -128,6 +152,22 @@ impl AppStateManager {
 
     pub fn set_nextui_tag(&self, tag: Option<Tag>) {
         self.state.lock().nextui_tag = tag;
+    }
+
+    pub fn set_nextui_releases_and_tags(&self, releases_and_tags: Option<Vec<ReleaseAndTag>>) {
+        self.state.lock().nextui_releases_and_tags = releases_and_tags;
+    }
+
+    pub fn set_nextui_releases_and_tags_index(&self, releases_and_tags_index: Option<usize>) {
+        self.state.lock().nextui_releases_and_tags_index = releases_and_tags_index;
+    }
+
+    pub fn set_release_selection_menu(&self, release_selection_menu: bool) {
+        self.state.lock().release_selection_menu = release_selection_menu;
+    }
+
+    pub fn set_release_selection_confirmed(&self, release_selection_confirmed: bool) {
+        self.state.lock().release_selection_confirmed = release_selection_confirmed;
     }
 
     // Combined operations

--- a/src/github.rs
+++ b/src/github.rs
@@ -22,3 +22,9 @@ pub struct Tag {
 pub struct Commit {
     pub sha: String,
 }
+
+#[derive(Clone, Debug)]
+pub struct ReleaseAndTag {
+    pub release: Release,
+    pub tag: Tag,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,13 +24,6 @@ fn main() -> Result<()> {
     // Initialize application state
     let app_state: &'static AppStateManager = Box::leak(Box::new(AppStateManager::new()));
 
-    // Self-update
-    let app_state_clone = app_state.clone();
-    thread::spawn(move || {
-        do_self_update(&app_state_clone);
-        do_nextui_release_check(&app_state_clone);
-    });
-
     // Get current NextUI version
     let version_file =
         std::fs::read_to_string(SDCARD_ROOT.to_owned() + ".system/version.txt").unwrap_or_default();
@@ -39,6 +32,13 @@ fn main() -> Result<()> {
         .nth(1)
         .map(std::borrow::ToOwned::to_owned);
     app_state.set_current_version(current_sha);
+
+    // Self-update
+    let app_state_clone = app_state.clone();
+    thread::spawn(move || {
+        do_self_update(&app_state_clone);
+        do_nextui_release_check(&app_state_clone);
+    });
 
     run_ui(app_state)?;
 


### PR DESCRIPTION
-     Added new option X to open version selector from primary "latest version" screen
-     Added a warning landing screen for version selector to indicate that downgrading is not fully supported by NextUI
-     Added the version selector after warning confirmation allowing for scrolling left/right through different available releases. Offers up to the most recent 100 releases (paired with the 100 most recent tags)

